### PR TITLE
fix: set `decorate_workers_output` to `no`

### DIFF
--- a/php/7.4/fpm-nginx/www.conf
+++ b/php/7.4/fpm-nginx/www.conf
@@ -91,4 +91,4 @@ clear_env = no
 catch_workers_output = yes
 
 ; Remove the 'child 10 said into stderr' prefix in the log and only show the actual message.
-decorate_workers_output = yes
+decorate_workers_output = no

--- a/php/8.0/fpm-nginx/www.conf
+++ b/php/8.0/fpm-nginx/www.conf
@@ -91,4 +91,4 @@ clear_env = no
 catch_workers_output = yes
 
 ; Remove the 'child 10 said into stderr' prefix in the log and only show the actual message.
-decorate_workers_output = yes
+decorate_workers_output = no

--- a/php/8.2/fpm-nginx/www.conf
+++ b/php/8.2/fpm-nginx/www.conf
@@ -91,4 +91,4 @@ clear_env = no
 catch_workers_output = yes
 
 ; Remove the 'child 10 said into stderr' prefix in the log and only show the actual message.
-decorate_workers_output = yes
+decorate_workers_output = no

--- a/php/8.3/fpm-nginx/www.conf
+++ b/php/8.3/fpm-nginx/www.conf
@@ -91,4 +91,4 @@ clear_env = no
 catch_workers_output = yes
 
 ; Remove the 'child 10 said into stderr' prefix in the log and only show the actual message.
-decorate_workers_output = yes
+decorate_workers_output = no


### PR DESCRIPTION
## Description

Removes `WARNING: [pool www] child 19 said into stdout:` from the log entries.

## Before submitting (or marking as "ready for review")

- [x] Does the pull request title follow the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) specification?
- [x] Have you performed a self-review of the code
- [ ] Have you have added tests that prove the fix or feature is effective and working
- [ ] Did you make sure to update any documentation relating to this change?
