### PR TITLE
ci: add scheduled rebuild of images

### DIFF
--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -4,6 +4,8 @@ on:
   push:
     branches:
       - main
+  schedule:
+    - cron: 0 * * * 2
 
 permissions:
   contents: read
@@ -19,7 +21,7 @@ jobs:
       tag_name: ${{ steps.release.outputs.tag_name }}
       release_created: ${{ steps.release.outputs.release_created }}
     steps:
-      - uses: google-github-actions/release-please-action@v4
+      - uses: googleapis/release-please-action@v4
         id: release
         with:
           release-type: simple
@@ -49,7 +51,7 @@ jobs:
 
   docker:
     name: Docker
-    if: ${{ needs.release-please.outputs.release_created || needs.orchestrator.outputs.changed-directories }}
+    if: ${{ needs.release-please.outputs.release_created || needs.orchestrator.outputs.changed-directories || github.event_name == 'schedule' }}
     concurrency:
       group: docker-${{ matrix.base }}
     needs:
@@ -67,20 +69,21 @@ jobs:
           - php/8.2/cli
           - php/8.3/cli
         exclude:
-          - base: ${{ needs.release-please.outputs.release_created || contains(needs.orchestrator.outputs.changed-directories, 'php/7.4/fpm-nginx') && 'ignored' || 'php/7.4/fpm-nginx' }}
-          - base: ${{ needs.release-please.outputs.release_created || contains(needs.orchestrator.outputs.changed-directories, 'php/8.0/fpm-nginx') && 'ignored' || 'php/8.0/fpm-nginx' }}
-          - base: ${{ needs.release-please.outputs.release_created || contains(needs.orchestrator.outputs.changed-directories, 'php/8.2/fpm-nginx') && 'ignored' || 'php/8.2/fpm-nginx' }}
-          - base: ${{ needs.release-please.outputs.release_created || contains(needs.orchestrator.outputs.changed-directories, 'php/8.3/fpm-nginx') && 'ignored' || 'php/8.3/fpm-nginx' }}
-          - base: ${{ needs.release-please.outputs.release_created || contains(needs.orchestrator.outputs.changed-directories, 'php/8.0/cli') && 'ignored' || 'php/8.0/cli' }}
-          - base: ${{ needs.release-please.outputs.release_created || contains(needs.orchestrator.outputs.changed-directories, 'php/8.2/cli') && 'ignored' || 'php/8.2/cli' }}
-          - base: ${{ needs.release-please.outputs.release_created || contains(needs.orchestrator.outputs.changed-directories, 'php/8.3/cli') && 'ignored' || 'php/8.3/cli' }}
+          - base: ${{ github.event_name == 'schedule' || needs.release-please.outputs.release_created || contains(needs.orchestrator.outputs.changed-directories, 'php/7.4/fpm-nginx') && 'ignored' || 'php/7.4/fpm-nginx' }}
+          - base: ${{ github.event_name == 'schedule' || needs.release-please.outputs.release_created || contains(needs.orchestrator.outputs.changed-directories, 'php/8.0/fpm-nginx') && 'ignored' || 'php/8.0/fpm-nginx' }}
+          - base: ${{ github.event_name == 'schedule' || needs.release-please.outputs.release_created || contains(needs.orchestrator.outputs.changed-directories, 'php/8.2/fpm-nginx') && 'ignored' || 'php/8.2/fpm-nginx' }}
+          - base: ${{ github.event_name == 'schedule' || needs.release-please.outputs.release_created || contains(needs.orchestrator.outputs.changed-directories, 'php/8.3/fpm-nginx') && 'ignored' || 'php/8.3/fpm-nginx' }}
+          - base: ${{ github.event_name == 'schedule' || needs.release-please.outputs.release_created || contains(needs.orchestrator.outputs.changed-directories, 'php/8.0/cli') && 'ignored' || 'php/8.0/cli' }}
+          - base: ${{ github.event_name == 'schedule' || needs.release-please.outputs.release_created || contains(needs.orchestrator.outputs.changed-directories, 'php/8.2/cli') && 'ignored' || 'php/8.2/cli' }}
+          - base: ${{ github.event_name == 'schedule' || needs.release-please.outputs.release_created || contains(needs.orchestrator.outputs.changed-directories, 'php/8.3/cli') && 'ignored' || 'php/8.3/cli' }}
     uses: ./.github/workflows/docker.yaml
     with:
-      version: ${{ needs.release-please.outputs.release_created && needs.release-please.outputs.tag_name || github.sha }}
-      local-path: ${{ matrix.base }}
+      image-version: ${{ (needs.release-please.outputs.release_created || github.event_name == 'schedule') && needs.release-please.outputs.tag_name || github.sha }}
+      dockerfile-directory:  ${{ matrix.base }}
       repository: ${{ matrix.base }}
       push: true
       is-release: ${{ needs.release-please.outputs.release_created == 'true' }}
+      is-schedule-release: ${{ github.event_name == 'schedule' }}
     permissions:
       contents: read
       id-token: write

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -53,8 +53,8 @@ jobs:
           - base: ${{ contains(needs.orchestrator.outputs.changed-directories, 'php/8.3/cli') && 'ignored' || 'php/8.3/cli' }}
     uses: ./.github/workflows/docker.yaml
     with:
-      version: ${{ github.event.pull_request.head.sha }}
-      local-path: ${{ matrix.base }}
+      image-version: ${{ github.event.pull_request.head.sha }}
+      dockerfile-directory: ${{ matrix.base }}
       repository: ${{ matrix.base }}
     permissions:
       contents: read

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -8,18 +8,27 @@ on:
         required: false
       repository:
         type: string
+        description: The name of the repository in the registry
         required: true
-      local-path:
+      dockerfile-directory:
         type: string
+        description: The directory containing the Dockerfile
         required: true
-      version:
+      image-version:
         type: string
+        description: The version of the image
         required: true
       push:
         type: boolean
+        description: Whether to push the image to the registry
         default: false
       is-release:
         type: boolean
+        description: Whether this is a release build
+        default: false
+      is-schedule-release:
+        type: boolean
+        description: Whether this is a release build that is ran from a schedule
         default: false
 
 env:
@@ -36,11 +45,11 @@ jobs:
       - uses: actions/checkout@v4
         with:
           ref: ${{ inputs.ref || null }}
-          sparse-checkout: ${{ inputs.local-path }}
+          sparse-checkout: ${{ inputs.dockerfile-directory }}
 
       - uses: hadolint/hadolint-action@v3.1.0
         with:
-          dockerfile: ${{ inputs.local-path }}/Dockerfile
+          dockerfile: ${{ inputs.dockerfile-directory }}/Dockerfile
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
@@ -54,9 +63,9 @@ jobs:
             ${{ env.REGISTRY_MIRROR }}/dvsa/dvsa-docker-images/${{ inputs.repository }}
           tags: |
             type=raw,value=latest
-            type=semver,enable=${{ inputs.is-release }},pattern={{major}}.{{minor}},value=${{ inputs.version }}
-            type=semver,enable=${{ inputs.is-release }},pattern={{major}},value=${{ inputs.version }}
-            type=semver,enable=${{ inputs.is-release }},pattern={{version}},value=${{ inputs.version }}
+            type=semver,enable=${{ inputs.is-release || inputs.is-schedule-release }},pattern={{major}}.{{minor}},value=${{ inputs.image-version }}
+            type=semver,enable=${{ inputs.is-release || inputs.is-schedule-release }},pattern={{major}},value=${{ inputs.image-version }}
+            type=semver,enable=${{ inputs.is-release }},pattern={{version}},value=${{ inputs.image-version }}
 
       - name: Configure AWS credentials
         if: ${{ inputs.push }}
@@ -76,12 +85,12 @@ jobs:
         id: mutable-meta
         uses: docker/metadata-action@v5
         with:
-          # Only required for ECR (the main registry).
+          # Only required for ECR (the main registry) as the mirror registry (GHCR) doesn't support tag immutability.
           images: ${{ env.REGISTRY }}/${{ inputs.repository }}
           tags: |
             type=raw,value=latest
-            type=semver,enable=${{ inputs.is-release }},pattern={{major}}.{{minor}},value=${{ inputs.version }}
-            type=semver,enable=${{ inputs.is-release }},pattern={{major}},value=${{ inputs.version }}
+            type=semver,enable=${{ inputs.is-release || inputs.is-schedule-release }},pattern={{major}}.{{minor}},value=${{ inputs.image-version }}
+            type=semver,enable=${{ inputs.is-release || inputs.is-schedule-release }},pattern={{major}},value=${{ inputs.image-version }}
 
       - name: Untag mutable tags
         if: ${{ inputs.push && steps.mutable-meta.outputs.tags }}
@@ -110,13 +119,19 @@ jobs:
         id: build-and-push
         uses: docker/build-push-action@v5
         with:
-          context: ${{ inputs.local-path }}
+          context: ${{ inputs.dockerfile-directory }}
           platforms: linux/amd64,linux/arm64
           push: ${{ inputs.push }}
+          load: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
+
+      - name: Scan
+        uses: aquasecurity/trivy-action@0.23.0
+        with:
+          image-ref: ${{ steps.build-and-push.outputs.imageid }}
 
       - name: Setup Notation CLI
         if: ${{ inputs.push }}


### PR DESCRIPTION
Adds scheduled re-building and pushing of Docker images.

All the testing needs to happen on the `main` branch so needs to be merged. This will be reverted or iterated upon error.