### PR TITLE
fix: Remove PHP CLI 8.0 from workflows

### DIFF
--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -70,14 +70,12 @@ jobs:
           - php/8.2/fpm-nginx
           - php/8.2/fpm-apache
           - php/8.3/fpm-nginx
-          - php/8.0/cli
           - php/8.2/cli
           - php/8.3/cli
         exclude:
           - base: ${{ github.event_name == 'schedule' || needs.release-please.outputs.release_created || contains(needs.orchestrator.outputs.changed-directories, 'php/8.2/fpm-nginx') && 'ignored' || 'php/8.2/fpm-nginx' }}
           - base: ${{ github.event_name == 'schedule' || needs.release-please.outputs.release_created || contains(needs.orchestrator.outputs.changed-directories, 'php/8.2/fpm-apache') && 'ignored' || 'php/8.2/fpm-apache' }}
           - base: ${{ github.event_name == 'schedule' || needs.release-please.outputs.release_created || contains(needs.orchestrator.outputs.changed-directories, 'php/8.3/fpm-nginx') && 'ignored' || 'php/8.3/fpm-nginx' }}
-          - base: ${{ github.event_name == 'schedule' || needs.release-please.outputs.release_created || contains(needs.orchestrator.outputs.changed-directories, 'php/8.0/cli') && 'ignored' || 'php/8.0/cli' }}
           - base: ${{ github.event_name == 'schedule' || needs.release-please.outputs.release_created || contains(needs.orchestrator.outputs.changed-directories, 'php/8.2/cli') && 'ignored' || 'php/8.2/cli' }}
           - base: ${{ github.event_name == 'schedule' || needs.release-please.outputs.release_created || contains(needs.orchestrator.outputs.changed-directories, 'php/8.3/cli') && 'ignored' || 'php/8.3/cli' }}
     uses: ./.github/workflows/docker.yaml

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -36,14 +36,12 @@ jobs:
           - php/8.2/fpm-nginx
           - php/8.2/fpm-apache
           - php/8.3/fpm-nginx
-          - php/8.0/cli
           - php/8.2/cli
           - php/8.3/cli
         exclude:
           - base: ${{ contains(needs.orchestrator.outputs.changed-directories, 'php/8.2/fpm-nginx') && 'ignored' || 'php/8.2/fpm-nginx' }}
           - base: ${{ contains(needs.orchestrator.outputs.changed-directories, 'php/8.2/fpm-apache') && 'ignored' || 'php/8.2/fpm-apache' }}
           - base: ${{ contains(needs.orchestrator.outputs.changed-directories, 'php/8.3/fpm-nginx') && 'ignored' || 'php/8.3/fpm-nginx' }}
-          - base: ${{ contains(needs.orchestrator.outputs.changed-directories, 'php/8.0/cli') && 'ignored' || 'php/8.0/cli' }}
           - base: ${{ contains(needs.orchestrator.outputs.changed-directories, 'php/8.2/cli') && 'ignored' || 'php/8.2/cli' }}
           - base: ${{ contains(needs.orchestrator.outputs.changed-directories, 'php/8.3/cli') && 'ignored' || 'php/8.3/cli' }}
     uses: ./.github/workflows/docker.yaml


### PR DESCRIPTION
## Description

Remove the Apache PHP8.0 CLI image from the workflows. This was a timing issue between new images added by MOT team and older images removed by VOL team

Related issue: https://dvsa.atlassian.net/browse/BL-17333

## Before submitting (or marking as "ready for review")

- [x] Does the pull request title follow the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) specification?
- [x] Have you performed a self-review of the code
- [x] Have you have added tests that prove the fix or feature is effective and working
- [ ] Did you make sure to update any documentation relating to this change?
