### PR TITLE
chore: remove trivy scan

### DIFF
--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -164,20 +164,17 @@ jobs:
           tags: image-scan:latest
           cache-from: type=gha,scope=${{ inputs.repository }}
 
-      - name: Scan
+      - name: Scan with Grype
+        uses: anchore/scan-action@v6
         id: scan
-        uses: aquasecurity/trivy-action@0.35.0
         with:
-          image-ref: ${{ steps.build-and-push.outputs.imageid }}
-          exit-code: '1'
-          ignore-unfixed: true
-          format: "sarif"
-          output: "trivy-results.sarif"
-          severity: "MEDIUM,HIGH,CRITICAL"
-          limit-severities-for-sarif: true
+          image: ${{ steps.build-and-push.outputs.imageid }}
+          severity-cutoff: medium
+          fail-build: true
+          output-format: sarif
 
-      - name: Upload Trivy scan results to GitHub Code Scanning
-        if: ${{ always() && !cancelled() && steps.scan.outcome == 'success' || steps.scan.outcome == 'failure' }}
-        uses: github/codeql-action/upload-sarif@v4
+      - name: Upload Grype scan results to GitHub Code Scanning
+        if: always()
+        uses: github/codeql-action/upload-sarif@v3
         with:
-          sarif_file: 'trivy-results.sarif'
+          sarif_file: ${{ steps.scan.outputs.sarif }}


### PR DESCRIPTION
## Description

As per title Trivy has had one too many security issues.

Related issue: [JIRA_TICKET_NUMBER](LINK_TO_JIRA_TICKET)

## Before submitting (or marking as "ready for review")

- [x] Does the pull request title follow the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) specification?
- [x] Have you performed a self-review of the code
- [ ] Have you have added tests that prove the fix or feature is effective and working
- [ ] Did you make sure to update any documentation relating to this change?
