### PR TITLE
chore: alter grype severity cutoff level

### DIFF
--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -169,9 +169,10 @@ jobs:
         id: scan
         with:
           image: ${{ steps.build-and-push.outputs.imageid }}
-          severity-cutoff: medium
+          severity-cutoff: high # This is only until 30th June 2026 until at which point it needs to be reviewd with IM&S
           fail-build: true
           output-format: sarif
+          only-fixed: true
 
       - name: Upload Grype scan results to GitHub Code Scanning
         if: always()


### PR DESCRIPTION
## Description

In consultation with IM&S we have increased the severity level to ensure that projects can catchup with patching rather than grype failing everything when it is running a CD build.

Related issue: [JIRA_TICKET_NUMBER](LINK_TO_JIRA_TICKET)

## Before submitting (or marking as "ready for review")

- [ ] Does the pull request title follow the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) specification?
- [ ] Have you performed a self-review of the code
- [ ] Have you have added tests that prove the fix or feature is effective and working
- [ ] Did you make sure to update any documentation relating to this change?
