### PR TITLE
change scan step to not use cache but push to cache

### DIFF
--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -162,7 +162,7 @@ jobs:
           platforms: linux/arm64
           load: true
           tags: image-scan:latest
-          cache-from: type=gha,scope=${{ inputs.repository }}
+          cache-to: type=gha,mode=max,scope=${{ inputs.repository }}
 
       - name: Scan with Grype
         uses: anchore/scan-action@v6


### PR DESCRIPTION
change logic so that the scan wont use the cached objects as it was scanning old images not the latest available.

## Description
Currently the logic does the scan before the build job - but the build job is the thing that pushes to the cache. So the scan is always using an old version of the base image from the last build. The scan should always pull fresh and scan that - then update the cache so that the build step can use that newly cached data to build faster.
## Before submitting (or marking as "ready for review")

- [ Y] Does the pull request title follow the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) specification?
- [ Y] Have you performed a self-review of the code
- [ Y] Have you have added tests that prove the fix or feature is effective and working
- [ Y] Did you make sure to update any documentation relating to this change?
