### PR TITLE
feat: add php 8.5 base images (fpm-nginx, cli)

### DIFF
--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -73,9 +73,11 @@ jobs:
           - php/8.2/fpm-apache
           - php/8.3/fpm-nginx
           - php/8.4/fpm-nginx
+          - php/8.5/fpm-nginx
           - php/8.2/cli
           - php/8.3/cli
           - php/8.4/cli
+          - php/8.5/cli
           - squid/6.12
           - squid/7.3
           - java/8/amazoncorretto
@@ -85,9 +87,11 @@ jobs:
           - base: ${{ github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' || needs.release-please.outputs.release_created == 'true' || contains(needs.orchestrator.outputs.changed-directories, 'php/8.2/fpm-apache') && 'ignored' || 'php/8.2/fpm-apache' }}
           - base: ${{ github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' || needs.release-please.outputs.release_created == 'true' || contains(needs.orchestrator.outputs.changed-directories, 'php/8.3/fpm-nginx') && 'ignored' || 'php/8.3/fpm-nginx' }}
           - base: ${{ github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' || needs.release-please.outputs.release_created == 'true' || contains(needs.orchestrator.outputs.changed-directories, 'php/8.4/fpm-nginx') && 'ignored' || 'php/8.4/fpm-nginx' }}
+          - base: ${{ github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' || needs.release-please.outputs.release_created == 'true' || contains(needs.orchestrator.outputs.changed-directories, 'php/8.5/fpm-nginx') && 'ignored' || 'php/8.5/fpm-nginx' }}
           - base: ${{ github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' || needs.release-please.outputs.release_created == 'true' || contains(needs.orchestrator.outputs.changed-directories, 'php/8.2/cli') && 'ignored' || 'php/8.2/cli' }}
           - base: ${{ github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' || needs.release-please.outputs.release_created == 'true' || contains(needs.orchestrator.outputs.changed-directories, 'php/8.3/cli') && 'ignored' || 'php/8.3/cli' }}
           - base: ${{ github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' || needs.release-please.outputs.release_created == 'true' || contains(needs.orchestrator.outputs.changed-directories, 'php/8.4/cli') && 'ignored' || 'php/8.4/cli' }}
+          - base: ${{ github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' || needs.release-please.outputs.release_created == 'true' || contains(needs.orchestrator.outputs.changed-directories, 'php/8.5/cli') && 'ignored' || 'php/8.5/cli' }}
           - base: ${{ github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' || needs.release-please.outputs.release_created == 'true' || contains(needs.orchestrator.outputs.changed-directories, 'squid/6.12') && 'ignored' || 'squid/6.12' }}
           - base: ${{ github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' || needs.release-please.outputs.release_created == 'true' || contains(needs.orchestrator.outputs.changed-directories, 'squid/7.3') && 'ignored' || 'squid/7.3' }}
           - base: ${{ github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' || needs.release-please.outputs.release_created == 'true' || contains(needs.orchestrator.outputs.changed-directories, 'java/8/amazoncorretto') && 'ignored' || 'java/8/amazoncorretto' }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -37,9 +37,11 @@ jobs:
           - php/8.2/fpm-apache
           - php/8.3/fpm-nginx
           - php/8.4/fpm-nginx
+          - php/8.5/fpm-nginx
           - php/8.2/cli
           - php/8.3/cli
           - php/8.4/cli
+          - php/8.5/cli
           - logstash/8.16.0/batch
           - squid/6.12
           - squid/7.3
@@ -50,9 +52,11 @@ jobs:
           - base: ${{ contains(needs.orchestrator.outputs.changed-directories, 'php/8.2/fpm-apache') && 'ignored' || 'php/8.2/fpm-apache' }}
           - base: ${{ contains(needs.orchestrator.outputs.changed-directories, 'php/8.3/fpm-nginx') && 'ignored' || 'php/8.3/fpm-nginx' }}
           - base: ${{ contains(needs.orchestrator.outputs.changed-directories, 'php/8.4/fpm-nginx') && 'ignored' || 'php/8.4/fpm-nginx' }}
+          - base: ${{ contains(needs.orchestrator.outputs.changed-directories, 'php/8.5/fpm-nginx') && 'ignored' || 'php/8.5/fpm-nginx' }}
           - base: ${{ contains(needs.orchestrator.outputs.changed-directories, 'php/8.2/cli') && 'ignored' || 'php/8.2/cli' }}
           - base: ${{ contains(needs.orchestrator.outputs.changed-directories, 'php/8.3/cli') && 'ignored' || 'php/8.3/cli' }}
           - base: ${{ contains(needs.orchestrator.outputs.changed-directories, 'php/8.4/cli') && 'ignored' || 'php/8.4/cli' }}
+          - base: ${{ contains(needs.orchestrator.outputs.changed-directories, 'php/8.5/cli') && 'ignored' || 'php/8.5/cli' }}
           - base: ${{ contains(needs.orchestrator.outputs.changed-directories, 'logstash/8.16.0/batch') && 'ignored' || 'logstash/8.16.0/batch' }}
           - base: ${{ contains(needs.orchestrator.outputs.changed-directories, 'squid/6.12') && 'ignored' || 'squid/6.12' }}
           - base: ${{ contains(needs.orchestrator.outputs.changed-directories, 'squid/7.3') && 'ignored' || 'squid/7.3' }}

--- a/php/8.5/cli/Dockerfile
+++ b/php/8.5/cli/Dockerfile
@@ -1,0 +1,13 @@
+FROM php:8.5-cli-alpine3.24
+
+RUN apk update --no-cache \
+    && apk upgrade --no-cache
+
+# Copy the PHP production configuration.
+RUN cp "${PHP_INI_DIR}/php.ini-production" "${PHP_INI_DIR}/php.ini" \
+    && chown www-data "${PHP_INI_DIR}/php.ini"
+
+# Copy the configuration files.
+COPY php.ini ${PHP_INI_DIR}/conf.d/zzz-dvsa-base.ini
+
+USER www-data

--- a/php/8.5/cli/php.ini
+++ b/php/8.5/cli/php.ini
@@ -1,0 +1,24 @@
+[PHP]
+
+; This directive controls whether or not and where PHP will output errors,
+; notices and warnings too. Error output is very useful during development, but
+; it could be very dangerous in production environments. Depending on the code
+; which is triggering the error, sensitive information could potentially leak
+; out of your application such as database usernames and passwords or worse.
+; For production environments, we recommend logging errors rather than
+; sending them to STDOUT.
+; Possible Values:
+;   Off = Do not display any errors
+;   stderr = Display errors to STDERR (affects only CGI/CLI binaries!)
+;   On or stdout = Display errors to STDOUT
+; Default Value: On
+; Development Value: On
+; Production Value: Off
+; https://php.net/display-errors
+display_errors = stderr
+
+[Date]
+
+; Defines the default timezone used by the date functions
+; https://php.net/date.timezone
+date.timezone = "UTC"

--- a/php/8.5/fpm-nginx/Dockerfile
+++ b/php/8.5/fpm-nginx/Dockerfile
@@ -1,0 +1,37 @@
+FROM php:8.5-fpm-alpine3.24
+
+# hadolint ignore=DL3018
+RUN apk update --no-cache \
+    && apk upgrade --no-cache \
+    && apk add --no-cache \
+        nginx~=1 \
+        supervisor~=4 \
+        python3 \
+        py3-pip \
+    && chown -R www-data /run /var/lib/nginx /var/log/nginx \
+    && pip install --no-cache-dir --break-system-packages --upgrade "wheel>=0.46.2" "jaraco-context>=6.1.0" \
+    && find /usr -name "wheel-*.dist-info" ! -name "wheel-0.46.2.dist-info" -type d -exec rm -rf {} + \
+    && find /usr -name "jaraco*context-*.dist-info" ! -name "*6.1.0*" -type d -exec rm -rf {} + \
+    && rm -rf /usr/lib/python*/site-packages/wheel-0.45.1.dist-info \
+    && apk del py3-pip \
+    && rm -rf /var/cache/apk/*
+
+# Copy the PHP production configuration.
+RUN cp "${PHP_INI_DIR}/php.ini-production" "${PHP_INI_DIR}/php.ini"
+
+# Copy the nginx configuration files.
+COPY nginx.conf /etc/nginx/nginx.conf
+
+# Copy the php configuration files.
+COPY php.ini ${PHP_INI_DIR}/conf.d/zzz-dvsa-base.ini
+COPY php-fpm.conf /usr/local/etc/php-fpm.d/zzz-www.conf
+
+# Copy the supervisor configuration files.
+COPY supervisord.conf /etc/supervisord.conf
+COPY supervisord /etc/supervisor/conf.d
+
+EXPOSE 80
+
+USER www-data
+
+CMD ["/usr/bin/supervisord"]

--- a/php/8.5/fpm-nginx/nginx.conf
+++ b/php/8.5/fpm-nginx/nginx.conf
@@ -1,0 +1,169 @@
+# Sets the worker threads to the number of CPU cores available in the system for best performance.
+# Should be > the number of CPU cores.
+# Maximum number of connections = worker_processes * worker_connections
+# Default: 1
+# https://nginx.org/en/docs/ngx_core_module.html#worker_processes
+worker_processes auto;
+
+# Maximum number of open files per worker process.
+# Should be > worker_connections.
+# Default: no limit
+# https://nginx.org/en/docs/ngx_core_module.html#worker_rlimit_nofile
+worker_rlimit_nofile 8192;
+
+# Provides the configuration file context in which the directives that affect connection processing are specified.
+# https://nginx.org/en/docs/ngx_core_module.html#events
+events {
+  # Should be < worker_rlimit_nofile.
+  # Default: 512
+  # https://nginx.org/en/docs/ngx_core_module.html#worker_connections
+  worker_connections 8000;
+}
+
+# Log errors and warnings to stderr so they are written to Docker logs.
+# This is only used when you don't override it on a `server` level
+# Default: logs/error.log error
+# https://nginx.org/en/docs/ngx_core_module.html#error_log
+error_log stderr error;
+
+# The file storing the process ID of the main process
+# Default: logs/nginx.pid
+# https://nginx.org/en/docs/ngx_core_module.html#pid
+pid /run/nginx.pid;
+
+http {
+    # Hide Nginx version information.
+    # https://nginx.org/en/docs/http/ngx_http_core_module.html#server_tokens
+    server_tokens off;
+
+    # Specify media (MIME) types for files.
+    # https://nginx.org/en/docs/http/ngx_http_core_module.html#types
+    include mime.types;
+
+    # Files without extension are treated as binary.
+    # https://nginx.org/en/docs/http/ngx_http_core_module.html#default_type
+    default_type application/octet-stream;
+
+    # Serve all resources labeled as `text/html` or `text/plain` with the media type `charset` parameter set to `UTF-8`.
+    # https://nginx.org/en/docs/http/ngx_http_charset_module.html#charset
+    charset utf-8;
+
+    # Update charset_types to match updated mime.types. `text/html` is always included by charset module.
+    # https://nginx.org/en/docs/http/ngx_http_charset_module.html#charset_types
+    charset_types
+        text/css
+        text/plain
+        text/vnd.wap.wml
+        text/javascript
+        text/markdown
+        text/calendar
+        text/x-component
+        text/vcard
+        text/cache-manifest
+        text/vtt
+        application/json
+        application/manifest+json;
+
+    # Adds the `$http_x_forwarded_for` to the log and formats in JSON for CloudWatch.
+    # https://nginx.org/en/docs/http/ngx_http_log_module.html#log_format
+    log_format main escape=json
+    '{'
+        '"remote_addr":"$remote_addr",'
+        '"remote_user":"$remote_user",'
+        '"time_local":"$time_local",'
+        '"request":"$request",'
+        '"status": "$status",'
+        '"body_bytes_sent":"$body_bytes_sent",'
+        '"http_referer":"$http_referer",'
+        '"http_user_agent":"$http_user_agent",'
+        '"http_x_forwarded_for":"$http_x_forwarded_for"'
+    '}';
+
+    # This is only used when you don't override it on a `server` level
+    # Default: logs/access.log combined
+    # https://nginx.org/en/docs/http/ngx_http_log_module.html#access_log
+    access_log /dev/stdout main;
+
+    # How long to allow each connection to stay idle.
+    # Longer values are better for each individual client, particularly for SSL, but means that worker connections are tied up longer.
+    # Default: 75s
+    # https://nginx.org/en/docs/http/ngx_http_core_module.html#keepalive_timeout
+    keepalive_timeout 20s;
+
+    # Speed up file transfers by using `sendfile()` to copy directly between descriptors rather than using `read()`/`write()``.
+    # For performance reasons, on FreeBSD systems w/ ZFS this option should be disabled as ZFS's ARC caches frequently used files in RAM by default.
+    # Default: off
+    # https://nginx.org/en/docs/http/ngx_http_core_module.html#sendfile
+    sendfile on;
+
+    # Don't send out partial frames; this increases throughput since TCP frames are filled up before being sent out.
+    # Default: off
+    # https://nginx.org/en/docs/http/ngx_http_core_module.html#tcp_nopush
+    # https://nginx.org/en/docs/http/ngx_http_core_module.html#tcp_nopush
+    tcp_nopush on;
+
+    # https://nginx.org/en/docs/http/ngx_http_gzip_module.html
+    # Enable gzip compression.
+    # Default: off
+    gzip on;
+
+    # Compression level (1-9).
+    # 5 is a perfect compromise between size and CPU usage, offering about 75% reduction for most ASCII files (almost identical to level 9).
+    # Default: 1
+    gzip_comp_level 5;
+
+    # Don't compress anything that's already small and unlikely to shrink much if at all (the default is 20 bytes, which is bad as that usually leads to larger files after gzipping).
+    # Default: 20
+    gzip_min_length 256;
+
+    # Compress data even for clients that are connecting to us via proxies, identified by the "Via" header (required for CloudFront).
+    # Default: off
+    gzip_proxied any;
+
+    # Tell proxies to cache both the gzipped and regular version of a resource whenever the client's Accept-Encoding capabilities header varies;
+    # Avoids the issue where a non-gzip capable client (which is extremely rare today) would display gibberish if their proxy gave them the gzipped version.
+    # Default: off
+    gzip_vary on;
+
+    # Compress all output labeled with one of the following MIME-types. `text/html` is always compressed by gzip module.
+    # Default: text/html
+    gzip_types
+      application/atom+xml
+      application/geo+json
+      application/javascript
+      application/x-javascript
+      application/json
+      application/ld+json
+      application/manifest+json
+      application/rdf+xml
+      application/rss+xml
+      application/vnd.ms-fontobject
+      application/wasm
+      application/x-web-app-manifest+json
+      application/xhtml+xml
+      application/xml
+      font/eot
+      font/otf
+      font/ttf
+      image/bmp
+      image/svg+xml
+      image/vnd.microsoft.icon
+      image/x-icon
+      text/cache-manifest
+      text/calendar
+      text/css
+      text/javascript
+      text/markdown
+      text/plain
+      text/xml
+      text/vcard
+      text/vnd.rim.location.xloc
+      text/vtt
+      text/x-component
+      text/x-cross-domain-policy;
+
+    # Include files in the conf.d folder.
+    # `server` configuration files should be placed in the conf.d folder.
+    # The configurations should be disabled by prefixing files with a dot.
+    include /etc/nginx/conf.d/*.conf;
+}

--- a/php/8.5/fpm-nginx/php-fpm.conf
+++ b/php/8.5/fpm-nginx/php-fpm.conf
@@ -1,0 +1,85 @@
+[global]
+
+pid = /run/php-fpm.pid
+
+error_log = /dev/stderr
+
+log_level = warning
+
+; https://github.com/docker-library/php/pull/725#issuecomment-443540114
+log_limit = 8192
+
+[www]
+
+; The address on which to accept FastCGI requests.
+; '/path/to/unix/socket' - to listen on a unix socket.
+listen = /run/php-fpm.socket
+
+; Choose how the process manager will control the number of child processes.
+; Possible Values:
+;   static  - a fixed number (pm.max_children) of child processes;
+;   dynamic - the number of child processes are set dynamically based on the
+;             following directives. With this process management, there will be
+;             always at least 1 children.
+;             pm.max_children      - the maximum number of children that can
+;                                    be alive at the same time.
+;             pm.start_servers     - the number of children created on startup.
+;             pm.min_spare_servers - the minimum number of children in 'idle'
+;                                    state (waiting to process). If the number
+;                                    of 'idle' processes is less than this
+;                                    number then some children will be created.
+;             pm.max_spare_servers - the maximum number of children in 'idle'
+;                                    state (waiting to process). If the number
+;                                    of 'idle' processes is greater than this
+;                                    number then some children will be killed.
+;             pm.max_spawn_rate    - the maximum number of rate to spawn child
+;                                    processes at once.
+;  ondemand - no children are created at startup. Children will be forked when
+;             new requests will connect. The following parameter are used:
+;             pm.max_children           - the maximum number of children that
+;                                         can be alive at the same time.
+;             pm.process_idle_timeout   - The number of seconds after which
+;                                         an idle process will be killed.
+; Note: This value is mandatory.
+pm = dynamic
+
+; The number of requests each child process should execute before respawning.
+; This can be useful to work around memory leaks in 3rd party libraries. For
+; endless request processing specify '0'. Equivalent to PHP_FCGI_MAX_REQUESTS.
+; Default Value: 0
+pm.max_requests = 200
+
+; The number of child processes to be created when pm is set to 'static' and the
+; maximum number of child processes when pm is set to 'dynamic' or 'ondemand'.
+; This value sets the limit on the number of simultaneous requests that will be
+; served. Equivalent to the ApacheMaxClients directive with mpm_prefork.
+; Equivalent to the PHP_FCGI_CHILDREN environment variable in the original PHP
+; CGI. The below defaults are based on a server without much resources. Don't
+; forget to tweak pm.* to fit your needs.
+; Note: Used when pm is set to 'static', 'dynamic' or 'ondemand'
+; Note: This value is mandatory.
+pm.max_children = 5
+
+; The number of child processes created on startup.
+; Note: Used only when pm is set to 'dynamic'
+; Default Value: (min_spare_servers + max_spare_servers) / 2
+pm.start_servers = 3
+
+; The desired minimum number of idle server processes.
+; Note: Used only when pm is set to 'dynamic'
+; Note: Mandatory when pm is set to 'dynamic'
+pm.min_spare_servers = 2
+
+; The desired maximum number of idle server processes.
+; Note: Used only when pm is set to 'dynamic'
+; Note: Mandatory when pm is set to 'dynamic'
+pm.max_spare_servers = 4
+
+; Allow FPM workers to have access to the ECS environment variables.
+clear_env = no
+
+; Send stdout/stderr from workers to the main error log.
+catch_workers_output = yes
+
+; Remove the 'child 10 said into stderr' prefix in the log and only show the actual message.
+decorate_workers_output = no

--- a/php/8.5/fpm-nginx/php.ini
+++ b/php/8.5/fpm-nginx/php.ini
@@ -1,0 +1,14 @@
+[PHP]
+
+; Decides whether PHP may expose the fact that it is installed on the server
+; (e.g. by adding its signature to the Web server header).  It is no security
+; threat in any way, but it makes it possible to determine whether you use PHP
+; on your server or not.
+; https://php.net/expose-php
+expose_php = Off
+
+[Date]
+
+; Defines the default timezone used by the date functions
+; https://php.net/date.timezone
+date.timezone = "UTC"

--- a/php/8.5/fpm-nginx/supervisord.conf
+++ b/php/8.5/fpm-nginx/supervisord.conf
@@ -1,0 +1,14 @@
+; supervisord config file.
+;
+; For more information on the config file, please see:
+; http://supervisord.org/configuration.html
+
+[supervisord]
+nodaemon=true
+loglevel=warn
+logfile=/dev/null
+logfile_maxbytes=0
+pidfile=/run/supervisord.pid
+
+[include]
+files = /etc/supervisor/conf.d/*.conf

--- a/php/8.5/fpm-nginx/supervisord/nginx.conf
+++ b/php/8.5/fpm-nginx/supervisord/nginx.conf
@@ -1,0 +1,14 @@
+; supervisord config file.
+;
+; For more information on the config file, please see:
+; http://supervisord.org/configuration.html
+
+[program:nginx]
+command=nginx -g 'daemon off;'
+priority=20
+stdout_logfile=/dev/stdout
+stdout_logfile_maxbytes=0
+stderr_logfile=/dev/stderr
+stderr_logfile_maxbytes=0
+autorestart=false
+startretries=0

--- a/php/8.5/fpm-nginx/supervisord/php-fpm.conf
+++ b/php/8.5/fpm-nginx/supervisord/php-fpm.conf
@@ -1,0 +1,14 @@
+; supervisord config file.
+;
+; For more information on the config file, please see:
+; http://supervisord.org/configuration.html
+
+[program:php-fpm]
+command=php-fpm --nodaemonize --force-stderr
+priority=10
+stdout_logfile=/dev/stdout
+stdout_logfile_maxbytes=0
+stderr_logfile=/dev/stderr
+stderr_logfile_maxbytes=0
+autorestart=false
+startretries=0


### PR DESCRIPTION
Initial PHP 8.5 image. Copies the 8.4 images verbatim with the 8.5 base image swapped in; the image configuration (php.ini, php-fpm.conf, nginx.conf, supervisord) is version-agnostic. Registers both images in the CI and CD build matrices.

Related issue: [VOL-7511](https://dvsa.atlassian.net/browse/VOL-7511)

## Before submitting (or marking as "ready for review")

- [x] Does the pull request title follow the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) specification?
- [x] Have you performed a self-review of the code
- [ ] Have you have added tests that prove the fix or feature is effective and working
- [ ] Did you make sure to update any documentation relating to this change?


[VOL-7511]: https://dvsa.atlassian.net/browse/VOL-7511?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ